### PR TITLE
UIの微調整

### DIFF
--- a/src/feature/populationTrends/components/RegionList/index.tsx
+++ b/src/feature/populationTrends/components/RegionList/index.tsx
@@ -25,7 +25,7 @@ const RegionList: React.FC<RegionListProps> = ({
   return (
     <div className="mb-5 flex flex-col">
       <p className="mb-2 w-fit border-b border-black text-sm">{region}</p>
-      <div className="flex flex-wrap gap-3">
+      <div className="flex flex-wrap gap-2 sm:gap-3">
         <RegionToggleButton allSelected={allSelected} region={region} toggleRegion={toggleRegion} />
         {prefectures.map((pref) => (
           <PrefectureButton

--- a/src/feature/populationTrends/components/SelectedPrefectures/index.tsx
+++ b/src/feature/populationTrends/components/SelectedPrefectures/index.tsx
@@ -16,10 +16,10 @@ const SelectedPrefectures: React.FC<SelectedPrefecturesProps> = ({
   togglePrefecture,
 }) => {
   return (
-    <div className="mb-8 flex flex-wrap gap-3 rounded-md border p-2">
+    <div className="mb-8 flex flex-wrap gap-2 rounded-md  border p-2 sm:gap-3">
       {selectedPrefs.length === 0 ? (
         <Button
-          className="flex items-center justify-center gap-2 rounded-lg border border-gray-300 px-2 py-1 text-sm shadow-md"
+          className="flex items-center justify-center gap-1 rounded-lg border border-gray-300 px-2 py-1 text-sm shadow-md sm:gap-2"
           onClick={() => {}}
         >
           <p className="text-xs text-gray-300 sm:text-sm">選択なし</p>
@@ -27,7 +27,7 @@ const SelectedPrefectures: React.FC<SelectedPrefecturesProps> = ({
       ) : (
         selectedPrefs.map((pref) => (
           <Button
-            className="flex items-center justify-center gap-2 rounded-lg border border-blue-600 px-2 py-1 text-sm shadow-md"
+            className="flex items-center justify-center gap-1 rounded-lg border border-blue-600 px-2 py-1 text-sm shadow-md sm:gap-2"
             key={pref.prefCode}
             onClick={() => togglePrefecture(pref.prefCode)}
           >

--- a/src/shared/components/Button/index.tsx
+++ b/src/shared/components/Button/index.tsx
@@ -9,7 +9,7 @@ interface ButtonProps {
 const Button: React.FC<ButtonProps> = ({ onClick, children, className }) => {
   return (
     <button
-      className={`flex items-center justify-center gap-2 rounded-lg border px-2 py-1 text-sm shadow-md ${className}`}
+      className={`flex items-center justify-center gap-1 rounded-lg  border px-2 py-1 text-sm shadow-md sm:gap-2 ${className}`}
       onClick={onClick}
     >
       {children}


### PR DESCRIPTION
## 概要
このプルリクエストでは、RegionListとSelectedPrefecturesコンポーネントのギャップサイズを更新しました。これにより、コンポーネント間のスペースが改善され、ユーザーインターフェースがより見やすくなります。

## 変更点
- RegionListコンポーネントのギャップサイズを更新
- SelectedPrefecturesコンポーネントのギャップサイズを更新

## 関連するIssue
<!-- 関連するIssueがある場合はここにリンクします -->
#34 
